### PR TITLE
New Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ For more information on the `llms.txt` standard, visit the official website: [ht
 
 - **Generate llms.txt**: Aggregate key content from your site into an easy-to-read format for machine learning models.
 - **Markdown Support**: Generate Markdown versions of posts, suitable for LLMs or for lightweight sharing.
+- **LLMs.txt Page CPT**: Create dedicated llms.txt pages with structured header fields and clean-editor mode.
+- **Header Templates**: Control the llms.txt header output with placeholders like `{post_title}`, `{post_author}`, `{scope}`, `{canonical_url}`, and more.
+- **Nested llms.txt URLs**: Serve llms.txt from a parent path like `/my-product/llms.txt` or `/documentation/llms.txt`.
+- **Child References Section**: Optionally append a formatted list of child llms.txt pages to the root output.
 - **Fully Customizable**: Customize which page or posts are included via an intuitive admin settings page.
 
 ## Installation
@@ -29,13 +33,19 @@ For more information on the `llms.txt` standard, visit the official website: [ht
 ## Usage
 
 1. **Configure Plugin Settings**: Navigate to **Settings** > **LLMs.txt Settings**.
-2. **Select Content**: Choose which page or post types to include in the `llms.txt` file.
+2. **Select Content Source**: Choose custom text, a page, or an **LLMs.txt Page**.
 3. **Markdown Support**: Enable Markdown output via settings and append `.md` to post URLs to view Markdown versions.
 4. **Access llms.txt**: Open `https://yourdomain.com/llms.txt` to view the file ready for LLM consumption.
+5. **Optional Parent URL**: For LLMs.txt Page entries, set **Output Parent** (e.g., `documentation`) to serve `https://yourdomain.com/documentation/llms.txt`.
 
 ### Admin Settings
 
-- **Selected Content for llms.txt**: Include specific pages or posts.
+- **llms.txt Source**: Choose Custom Text, Page, or LLMs.txt Page.
+- **Header Template**: Customize the header output for LLMs.txt Pages with placeholders.
+- **LLMs.txt Page**: Pick the LLMs.txt Page to output.
+- **Output Parent** (in LLMs.txt Page): Set a parent path to serve a nested llms.txt endpoint.
+- **Include All llms.txt Pages**: Append a child references section to the root llms.txt.
+- **Include Header**: Customize the header text shown above the child references list.
 - **Post Types to Include**: Define which types of content (e.g., posts, pages) appear in `llms.txt`.
 - **Post Limit**: Set the maximum number of posts to include.
 - **Markdown Support**: Enable or disable `.md` file extension for post URLs.
@@ -57,6 +67,10 @@ Once Markdown support is enabled, you can access Markdown versions in three ways
 
 Yes! The plugin can be configured to include specific post types and limit the number of posts included in the `llms.txt` file. You can also choose to include a specific page only.
 
+### Can I create multiple llms.txt files under different URLs?
+
+Yes. Create multiple **LLMs.txt Page** entries and assign different **Output Parent** values (e.g., `my-product`, `documentation`). Then access each file at `https://yourdomain.com/{parent}/llms.txt`.
+
 ## Screenshots
 
 1. **Admin Settings Page** - Easily manage content for `llms.txt` and enable Markdown support.
@@ -72,6 +86,12 @@ Yes! The plugin can be configured to include specific post types and limit the n
 You can view a demo of the plugin in action on my blog at [WebWizWork.com](https://www.webwizwork.com/llms.txt).
 
 ## Changelog
+
+### 1.2.0
+- Added LLMs.txt Page custom post type with clean editor mode.
+- Added header templates with placeholder support for llms.txt output.
+- Added Output Parent support to serve llms.txt under nested paths.
+- Added optional child references section listing all llms.txt pages.
 
 ### 1.1.0
 - Markdown versions can now be accessed by sending the "Accept: text/markdown" header.
@@ -95,4 +115,4 @@ Contributions are welcome! Feel free to fork the repository, submit issues, or c
 
 **Note:** This plugin uses the [league/html-to-markdown](https://github.com/thephpleague/html-to-markdown) library for HTML to Markdown conversion.
 
-Stable tag: 1.1.0
+Stable tag: 1.2.0

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ For more information on the `llms.txt` standard, visit the official website: [ht
 - **llms.txt Source**: Choose Custom Text, Page, or LLMs.txt Page.
 - **Header Template**: Customize the header output for LLMs.txt Pages with placeholders.
 - **LLMs.txt Page**: Pick the LLMs.txt Page to output.
-- **Output Parent** (in LLMs.txt Page): Set a parent path to serve a nested llms.txt endpoint.
 - **Include All llms.txt Pages**: Append a child references section to the root llms.txt.
 - **Include Header**: Customize the header text shown above the child references list.
 - **Post Types to Include**: Define which types of content (e.g., posts, pages) appear in `llms.txt`.
@@ -87,7 +86,7 @@ You can view a demo of the plugin in action on my blog at [WebWizWork.com](https
 
 ## Changelog
 
-### 1.2.0
+### 1.2.1
 - Added LLMs.txt Page custom post type with clean editor mode.
 - Added header templates with placeholder support for llms.txt output.
 - Added Output Parent support to serve llms.txt under nested paths.

--- a/admin/class-llms-txt-admin.php
+++ b/admin/class-llms-txt-admin.php
@@ -443,7 +443,7 @@ class LLMS_Txt_Admin {
 			);
 		}
 		echo '</select>';
-		echo '<p class="description">' . esc_html__( 'Choose the llms.txt Page to output in llms.txt.', 'llms-txt-for-wp' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'Choose the llms.txt Page to output in llms.txt. Content is output as-is (no HTML-to-Markdown conversion).', 'llms-txt-for-wp' ) . '</p>';
 		echo '</div>';
 	}
 

--- a/admin/class-llms-txt-admin.php
+++ b/admin/class-llms-txt-admin.php
@@ -60,6 +60,15 @@ class LLMS_Txt_Admin {
 		);
 
 		add_settings_field(
+			'header_template',
+			__( 'Header Template', 'llms-txt-for-wp' ),
+			array( $this, 'render_header_template_field' ),
+			'llms-txt-settings',
+			'llms_txt_general_section',
+			array( 'class' => 'llms-txt-header-template-row' )
+		);
+
+		add_settings_field(
 			'custom_text',
 			__( 'Custom llms.txt Text', 'llms-txt-for-wp' ),
 			array( $this, 'render_custom_text_field' ),
@@ -75,6 +84,15 @@ class LLMS_Txt_Admin {
 			'llms-txt-settings',
 			'llms_txt_general_section',
 			array( 'class' => 'llms-txt-selected-page-row' )
+		);
+
+		add_settings_field(
+			'selected_llms_page',
+			__( 'Selected llms.txt Page', 'llms-txt-for-wp' ),
+			array( $this, 'render_selected_llms_page_field' ),
+			'llms-txt-settings',
+			'llms_txt_general_section',
+			array( 'class' => 'llms-txt-llms-page-row' )
 		);
 
 		add_settings_field(
@@ -100,6 +118,23 @@ class LLMS_Txt_Admin {
 			'llms-txt-settings',
 			'llms_txt_general_section'
 		);
+
+		add_settings_field(
+			'include_all_llms_pages',
+			__( 'Include All llms.txt Pages', 'llms-txt-for-wp' ),
+			array( $this, 'render_include_all_llms_pages_field' ),
+			'llms-txt-settings',
+			'llms_txt_general_section'
+		);
+
+		add_settings_field(
+			'include_all_llms_pages_header',
+			__( 'Include Header', 'llms-txt-for-wp' ),
+			array( $this, 'render_include_all_llms_pages_header_field' ),
+			'llms-txt-settings',
+			'llms_txt_general_section',
+			array( 'class' => 'llms-txt-include-all-header-row' )
+		);
 	}
 
 	/**
@@ -113,10 +148,16 @@ class LLMS_Txt_Admin {
 			$source = $this->settings['source'];
 			$custom_display = 'custom' === $source ? 'table-row' : 'none';
 			$page_display = 'page' === $source ? 'table-row' : 'none';
+			$llms_page_display = 'llms_txt_page' === $source ? 'table-row' : 'none';
+			$header_template_display = 'llms_txt_page' === $source ? 'table-row' : 'none';
+			$include_all_header_display = 'yes' === $this->settings['include_all_llms_pages'] ? 'table-row' : 'none';
 			?>
 			<style>
 				.llms-txt-custom-text-row { display: <?php echo esc_attr( $custom_display ); ?>; }
 				.llms-txt-selected-page-row { display: <?php echo esc_attr( $page_display ); ?>; }
+				.llms-txt-llms-page-row { display: <?php echo esc_attr( $llms_page_display ); ?>; }
+				.llms-txt-header-template-row { display: <?php echo esc_attr( $header_template_display ); ?>; }
+				.llms-txt-include-all-header-row { display: <?php echo esc_attr( $include_all_header_display ); ?>; }
 			</style>
 			<form method="post" action="options.php">
 				<?php
@@ -166,6 +207,12 @@ class LLMS_Txt_Admin {
 				var customTextRow = customTextWrap ? customTextWrap.closest('tr') : null;
 				var selectedPostRow = selectedPostWrap ? selectedPostWrap.closest('tr') : null;
 				var customText = document.getElementById('llms_txt_settings_custom_text');
+				var llmsPageSelect = document.getElementById('llms_txt_settings_selected_llms_page');
+				var llmsPageWrap = document.getElementById('llms-txt-selected-llms-page-wrap');
+				var llmsPageRow = llmsPageWrap ? llmsPageWrap.closest('tr') : null;
+				var headerTemplateRow = document.querySelector('.llms-txt-header-template-row');
+				var includeAllPages = document.getElementById('llms_txt_settings_include_all_llms_pages');
+				var includeAllHeaderRow = document.querySelector('.llms-txt-include-all-header-row');
 				var postTypes = document.querySelectorAll('input[name="llms_txt_settings[post_types][]"]');
 				var mdSupport = document.getElementById('llms_txt_settings_enable_md_support');
 				var hint = document.getElementById('llms-txt-settings-hint');
@@ -187,11 +234,26 @@ class LLMS_Txt_Admin {
 					if (selectedPostWrap) {
 						selectedPostWrap.style.display = source === 'page' ? 'block' : 'none';
 					}
+					if (llmsPageWrap) {
+						llmsPageWrap.style.display = source === 'llms_txt_page' ? 'block' : 'none';
+					}
 					if (customTextRow) {
 						customTextRow.style.display = source === 'custom' ? 'table-row' : 'none';
 					}
 					if (selectedPostRow) {
 						selectedPostRow.style.display = source === 'page' ? 'table-row' : 'none';
+					}
+					if (llmsPageRow) {
+						llmsPageRow.style.display = source === 'llms_txt_page' ? 'table-row' : 'none';
+					}
+					if (headerTemplateRow) {
+						headerTemplateRow.style.display = source === 'llms_txt_page' ? 'table-row' : 'none';
+					}
+				}
+
+				function updateIncludeAllHeader() {
+					if (includeAllHeaderRow) {
+						includeAllHeaderRow.style.display = includeAllPages && includeAllPages.checked ? 'table-row' : 'none';
 					}
 				}
 
@@ -199,6 +261,8 @@ class LLMS_Txt_Admin {
 					var hasMdSupport = mdSupport.checked;
 					var selectedPostValue = selectedPost.value;
 					var selectedPostText = selectedPost.options[selectedPost.selectedIndex].textContent.trim();
+					var llmsPageValue = llmsPageSelect ? llmsPageSelect.value : '';
+					var llmsPageText = llmsPageSelect && llmsPageSelect.options[llmsPageSelect.selectedIndex] ? llmsPageSelect.options[llmsPageSelect.selectedIndex].textContent.trim() : '';
 					var source = getSelectedSource();
 					var types = Array.from(postTypes).filter(function(type) {
 						return type.checked;
@@ -208,8 +272,12 @@ class LLMS_Txt_Admin {
 
 					if (source === 'custom') {
 						hint.textContent = 'your custom text';
-					} else if (selectedPostValue) {
+					} else if (source === 'page' && selectedPostValue) {
 						hint.textContent = 'the content of the "' + selectedPostText + '" page';
+					} else if (source === 'llms_txt_page' && llmsPageValue) {
+						hint.textContent = 'the content of the "' + llmsPageText + '" llms.txt page';
+					} else if (source === 'llms_txt_page') {
+						hint.textContent = 'the selected llms.txt page content';
 					} else {
 						// hint.textContent = types.length ? 'all ' + types.join(', ') : 'just the site name and description';
 						if (types.length) {
@@ -243,6 +311,9 @@ class LLMS_Txt_Admin {
 					});
 				});
 				selectedPost.addEventListener('change', updateHint);
+				if (llmsPageSelect) {
+					llmsPageSelect.addEventListener('change', updateHint);
+				}
 				if (customText) {
 					customText.addEventListener('input', updateHint);
 				}
@@ -251,8 +322,12 @@ class LLMS_Txt_Admin {
 					type.addEventListener('change', updateHint);
 				});
 				mdSupport.addEventListener('change', updateHint);
+				if (includeAllPages) {
+					includeAllPages.addEventListener('change', updateIncludeAllHeader);
+				}
 
 				updateSourceFields();
+				updateIncludeAllHeader();
 				updateHint();
 			})();
 		</script>
@@ -289,6 +364,24 @@ class LLMS_Txt_Admin {
 			esc_html__( 'Page', 'llms-txt-for-wp' )
 		);
 		echo '</label>';
+		echo '<label style="display: inline-block; margin-left: 16px;">';
+		printf(
+			'<input type="radio" name="llms_txt_settings[source]" value="llms_txt_page" %s> %s',
+			checked( $source, 'llms_txt_page', false ),
+			esc_html__( 'llms.txt Page', 'llms-txt-for-wp' )
+		);
+		echo '</label>';
+	}
+
+	/**
+	 * Render header template field.
+	 */
+	public function render_header_template_field() {
+		printf(
+			'<textarea id="llms_txt_settings_header_template" name="llms_txt_settings[header_template]" rows="8" class="large-text code">%s</textarea>',
+			esc_textarea( $this->settings['header_template'] )
+		);
+		echo '<p class="description">' . esc_html__( 'Used to build the header for llms.txt Page output. You can include placeholders like {post_title}, {scope}, {canonical_url}, {post_author}, {authority_level}, {content_type}, {last_updated}.', 'llms-txt-for-wp' ) . '</p>';
 	}
 
 	/**
@@ -321,6 +414,36 @@ class LLMS_Txt_Admin {
 			)
 		);
 		echo '<p class="description">' . esc_html__( 'If a page is selected, only that page will be included in the llms.txt file. If no page is selected, all posts from selected post types will be included.', 'llms-txt-for-wp' ) . '</p>';
+		echo '</div>';
+	}
+
+	/**
+	 * Render selected llms.txt page field.
+	 */
+	public function render_selected_llms_page_field() {
+		$display = 'llms_txt_page' === $this->settings['source'] ? 'block' : 'none';
+		echo '<div id="llms-txt-selected-llms-page-wrap" style="display: ' . esc_attr( $display ) . ';">';
+		$llms_pages = get_posts(
+			array(
+				'post_type'      => 'llms_txt_page',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			)
+		);
+		echo '<select id="llms_txt_settings_selected_llms_page" name="llms_txt_settings[selected_llms_page]">';
+		echo '<option value="">' . esc_html__( 'Select an llms.txt page', 'llms-txt-for-wp' ) . '</option>';
+		foreach ( $llms_pages as $llms_page ) {
+			printf(
+				'<option value="%d" %s>%s</option>',
+				esc_attr( $llms_page->ID ),
+				selected( $this->settings['selected_llms_page'], $llms_page->ID, false ),
+				esc_html( $llms_page->post_title )
+			);
+		}
+		echo '</select>';
+		echo '<p class="description">' . esc_html__( 'Choose the llms.txt Page to output in llms.txt.', 'llms-txt-for-wp' ) . '</p>';
 		echo '</div>';
 	}
 
@@ -374,6 +497,30 @@ class LLMS_Txt_Admin {
 	}
 
 	/**
+	 * Render include all llms.txt pages field.
+	 */
+	public function render_include_all_llms_pages_field() {
+		echo '<p class="description"><label>';
+		printf(
+			'<input id="llms_txt_settings_include_all_llms_pages" type="checkbox" name="llms_txt_settings[include_all_llms_pages]" value="yes" %s>',
+			checked( $this->settings['include_all_llms_pages'], 'yes', false )
+		);
+		esc_html_e( 'Append links to all llms.txt Pages in the root llms.txt output.', 'llms-txt-for-wp' );
+		echo '</label></p>';
+	}
+
+	/**
+	 * Render include all llms.txt pages header field.
+	 */
+	public function render_include_all_llms_pages_header_field() {
+		printf(
+			'<textarea id="llms_txt_settings_include_all_llms_pages_header" name="llms_txt_settings[include_all_llms_pages_header]" rows="5" class="large-text code">%s</textarea>',
+			esc_textarea( $this->settings['include_all_llms_pages_header'] )
+		);
+		echo '<p class="description">' . esc_html__( 'Shown above the list of child llms.txt links.', 'llms-txt-for-wp' ) . '</p>';
+	}
+
+	/**
 	 * Validate settings.
 	 *
 	 * @param array $input The input array.
@@ -383,12 +530,16 @@ class LLMS_Txt_Admin {
 		$output = array();
 
 		$source = isset( $input['source'] ) ? sanitize_text_field( $input['source'] ) : 'custom';
-		$output['source'] = in_array( $source, array( 'custom', 'page' ), true ) ? $source : 'custom';
-		$output['custom_text']      = isset( $input['custom_text'] ) ? sanitize_textarea_field( $input['custom_text'] ) : '';
-		$output['selected_post']     = isset( $input['selected_post'] ) ? absint( $input['selected_post'] ) : '';
-		$output['post_types']        = isset( $input['post_types'] ) ? array_map( 'sanitize_text_field', $input['post_types'] ) : array();
-		$output['posts_limit']       = isset( $input['posts_limit'] ) ? absint( $input['posts_limit'] ) : 100;
-		$output['enable_md_support'] = isset( $input['enable_md_support'] ) ? 'yes' : 'no';
+		$output['source'] = in_array( $source, array( 'custom', 'page', 'llms_txt_page' ), true ) ? $source : 'custom';
+		$output['custom_text']        = isset( $input['custom_text'] ) ? sanitize_textarea_field( $input['custom_text'] ) : '';
+		$output['header_template']    = isset( $input['header_template'] ) ? sanitize_textarea_field( $input['header_template'] ) : '';
+		$output['selected_post']      = isset( $input['selected_post'] ) ? absint( $input['selected_post'] ) : '';
+		$output['selected_llms_page'] = isset( $input['selected_llms_page'] ) ? absint( $input['selected_llms_page'] ) : '';
+		$output['post_types']         = isset( $input['post_types'] ) ? array_map( 'sanitize_text_field', $input['post_types'] ) : array();
+		$output['posts_limit']              = isset( $input['posts_limit'] ) ? absint( $input['posts_limit'] ) : 100;
+		$output['enable_md_support']        = isset( $input['enable_md_support'] ) ? 'yes' : 'no';
+		$output['include_all_llms_pages']        = isset( $input['include_all_llms_pages'] ) ? 'yes' : 'no';
+		$output['include_all_llms_pages_header'] = isset( $input['include_all_llms_pages_header'] ) ? sanitize_textarea_field( $input['include_all_llms_pages_header'] ) : '';
 
 		return $output;
 	}

--- a/includes/class-llms-txt-core.php
+++ b/includes/class-llms-txt-core.php
@@ -84,12 +84,19 @@ class LLMS_Txt_Core {
 	 */
 	public static function get_settings() {
 		$defaults = array(
+			'source'            => 'custom',
+			'custom_text'       => '',
 			'selected_post'     => '',
 			'post_types'        => array(),
 			'posts_limit'       => 100,
 			'enable_md_support' => 'yes',
 		);
 
-		return wp_parse_args( get_option( 'llms_txt_settings', array() ), $defaults );
+		$options = get_option( 'llms_txt_settings', array() );
+		if ( is_array( $options ) && ! isset( $options['source'] ) ) {
+			$options['source'] = 'page';
+		}
+
+		return wp_parse_args( $options, $defaults );
 	}
 }

--- a/includes/class-llms-txt-cpt.php
+++ b/includes/class-llms-txt-cpt.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * CPT and meta handling for llms.txt Page.
+ *
+ * @package LLMsTxtForWP
+ */
+
+class LLMS_Txt_CPT {
+	/**
+	 * Register CPT-related hooks.
+	 */
+	public function init_hooks() {
+		add_action( 'init', array( $this, 'register_llms_txt_page_cpt' ) );
+		add_filter( 'use_block_editor_for_post_type', array( $this, 'disable_llms_txt_page_block_editor' ), 10, 2 );
+		add_action( 'add_meta_boxes', array( $this, 'add_llms_txt_page_meta_box' ) );
+		add_action( 'save_post_llms_txt_page', array( $this, 'save_llms_txt_page_meta' ), 10, 2 );
+		add_action( 'admin_head', array( $this, 'handle_llms_txt_page_admin_head' ) );
+	}
+
+	/**
+	 * Apply clean editor adjustments for the llms.txt Page post type.
+	 */
+	public function handle_llms_txt_page_admin_head() {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen || 'llms_txt_page' !== $screen->post_type ) {
+			return;
+		}
+
+		// Nuke any remaining media/editor button injections.
+		remove_all_actions( 'media_buttons' );
+		add_filter( 'quicktags_settings', array( $this, 'filter_llms_txt_page_quicktags_settings' ) );
+		add_filter( 'user_can_richedit', '__return_false' );
+	}
+
+	/**
+	 * Disable Quicktags buttons for the llms.txt Page post type.
+	 *
+	 * @param array $settings Quicktags settings.
+	 * @return array
+	 */
+	public function filter_llms_txt_page_quicktags_settings( $settings ) {
+		$settings['buttons'] = '';
+		return $settings;
+	}
+
+	/**
+	 * Register the llms.txt Page custom post type.
+	 */
+	public function register_llms_txt_page_cpt() {
+		$labels = array(
+			'name'               => __( 'LLMs.txt Pages', 'llms-txt-for-wp' ),
+			'singular_name'      => __( 'LLMs.txt Page', 'llms-txt-for-wp' ),
+			'add_new'            => __( 'Add New', 'llms-txt-for-wp' ),
+			'add_new_item'       => __( 'Add New LLMs.txt Page', 'llms-txt-for-wp' ),
+			'edit_item'          => __( 'Edit LLMs.txt Page', 'llms-txt-for-wp' ),
+			'new_item'           => __( 'New LLMs.txt Page', 'llms-txt-for-wp' ),
+			'view_item'          => __( 'View LLMs.txt Page', 'llms-txt-for-wp' ),
+			'search_items'       => __( 'Search LLMs.txt Pages', 'llms-txt-for-wp' ),
+			'not_found'          => __( 'No LLMs.txt Pages found.', 'llms-txt-for-wp' ),
+			'not_found_in_trash' => __( 'No LLMs.txt Pages found in Trash.', 'llms-txt-for-wp' ),
+			'all_items'          => __( 'LLMs.txt Pages', 'llms-txt-for-wp' ),
+		);
+
+		$args = array(
+			'labels'              => $labels,
+			'public'              => false,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'capability_type'     => 'post',
+			'hierarchical'        => false,
+			'supports'            => array( 'title', 'editor', 'revisions' ),
+			'menu_icon'           => 'dashicons-media-text',
+			'exclude_from_search' => true,
+			'publicly_queryable'  => false,
+			'show_in_rest'        => false,
+			'has_archive'         => false,
+			'rewrite'             => false,
+			'query_var'           => false,
+		);
+
+		register_post_type( 'llms_txt_page', $args );
+	}
+
+	/**
+	 * Disable block editor for the llms.txt Page post type.
+	 *
+	 * @param bool   $use_block_editor Whether to use the block editor.
+	 * @param string $post_type Post type.
+	 * @return bool
+	 */
+	public function disable_llms_txt_page_block_editor( $use_block_editor, $post_type ) {
+		if ( 'llms_txt_page' === $post_type ) {
+			return false;
+		}
+		return $use_block_editor;
+	}
+
+	/**
+	 * Add meta box for llms.txt Page fields.
+	 */
+	public function add_llms_txt_page_meta_box() {
+		add_meta_box(
+			'llms-txt-page-header',
+			__( 'LLMs.txt Header Fields', 'llms-txt-for-wp' ),
+			array( $this, 'render_llms_txt_page_meta_box' ),
+			'llms_txt_page',
+			'normal',
+			'default'
+		);
+	}
+
+	/**
+	 * Render llms.txt Page meta box.
+	 *
+	 * @param WP_Post $post Current post.
+	 */
+	public function render_llms_txt_page_meta_box( $post ) {
+		wp_nonce_field( 'llms_txt_page_meta', 'llms_txt_page_meta_nonce' );
+
+		$defaults = $this->get_header_template_defaults();
+		$fields = array(
+			'scope' => array(
+				'label' => __( 'Scope', 'llms-txt-for-wp' ),
+				'meta_key' => '_llms_txt_header_scope',
+				'type' => 'text',
+				'definition' => __( 'The specific entity, company, product, or subject area that the llms.txt file applies to. Can be left blank if there is only 1 llms.txt', 'llms-txt-for-wp' ),
+			),
+			'output_parent' => array(
+				'label' => __( 'Output Parent', 'llms-txt-for-wp' ),
+				'meta_key' => '_llms_txt_output_parent',
+				'type' => 'text',
+				'definition' => __( 'Enter a path relative to your site root where you want your llms.txt to be output.', 'llms-txt-for-wp' ),
+				'examples' => array(
+					array(
+						'value' => __( 'products/my-product', 'llms-txt-for-wp' ),
+						'description' => esc_url( site_url( '/products/my-product/llms.txt' ) ),
+					),
+					array(
+						'value' => __( 'my-service', 'llms-txt-for-wp' ),
+						'description' => esc_url( site_url( '/my-service/llms.txt' ) ),
+					),
+					array(
+						'value' => __( '/docs', 'llms-txt-for-wp' ),
+						'description' => esc_url( site_url( '/docs/llms.txt.' ) ),
+					),
+				),
+			),
+			'authority_level' => array(
+				'label' => __( 'Authority Level', 'llms-txt-for-wp' ),
+				'meta_key' => '_llms_txt_header_authority_level',
+				'type' => 'text',
+				'definition' => __( 'A declaration of how strongly the information in this file should be trusted and preferred when conflicting information exists.', 'llms-txt-for-wp' ),
+				'examples' => array(
+					array(
+						'value' => __( 'Authoritative', 'llms-txt-for-wp' ),
+						'description' => __( 'Primary source controlled by the product owner; should be preferred over marketing pages, blogs, and third-party content.', 'llms-txt-for-wp' ),
+					),
+					array(
+						'value' => __( 'Supplementary', 'llms-txt-for-wp' ),
+						'description' => __( 'Accurate but secondary; useful for detail, not precedence.', 'llms-txt-for-wp' ),
+					),
+					array(
+						'value' => __( 'Informational', 'llms-txt-for-wp' ),
+						'description' => __( 'Descriptive only; not intended to resolve conflicts.', 'llms-txt-for-wp' ),
+					),
+				),
+			),
+			'content_type' => array(
+				'label' => __( 'Content Type', 'llms-txt-for-wp' ),
+				'meta_key' => '_llms_txt_header_content_type',
+				'type' => 'text',
+				'definition' => __( 'The intended use of the file by AI systems.', 'llms-txt-for-wp' ),
+				'examples' => array(
+					array(
+						'value' => __( 'AI reference and summarization', 'llms-txt-for-wp' ),
+						'description' => __( 'Canonical summaries, definitions, and facts.', 'llms-txt-for-wp' ),
+					),
+					array(
+						'value' => __( 'AI reference and citation guidance', 'llms-txt-for-wp' ),
+						'description' => __( 'Entity definition plus preferred citation targets.', 'llms-txt-for-wp' ),
+					),
+					array(
+						'value' => __( 'AI technical reference', 'llms-txt-for-wp' ),
+						'description' => __( 'Specs, APIs, schemas, or developer-level detail.', 'llms-txt-for-wp' ),
+					),
+				),
+			),
+		);
+
+		echo '<table class="form-table"><tbody>';
+		foreach ( $fields as $key => $field ) {
+			$value = get_post_meta( $post->ID, $field['meta_key'], true );
+			if ( '' === $value && isset( $defaults[ $key ] ) ) {
+				$value = $defaults[ $key ];
+			}
+			echo '<tr>';
+			echo '<th scope="row"><label for="' . esc_attr( $field['meta_key'] ) . '">' . esc_html( $field['label'] ) . '</label></th>';
+			echo '<td>';
+			printf(
+				'<input class="regular-text" type="%s" id="%s" name="%s" value="%s">',
+				esc_attr( $field['type'] ),
+				esc_attr( $field['meta_key'] ),
+				esc_attr( $field['meta_key'] ),
+				esc_attr( $value )
+			);
+			if ( '_llms_txt_output_parent' === $field['meta_key'] ) {
+				$parent = trim( (string) $value, '/' );
+				if ( '' !== $parent ) {
+					$url = home_url( trailingslashit( $parent ) . 'llms.txt' );
+					echo ' <a class="description" href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'View llms.txt', 'llms-txt-for-wp' ) . '</a>';
+				}
+			}
+			if ( isset( $field['definition'] ) ) {
+				$definition = $field['definition'];
+				echo '<p class="description">' . esc_html( $definition ) . '</p>';
+			}
+			if ( isset( $field['examples'] ) && is_array( $field['examples'] ) ) {
+				echo '<p class="description"><strong>' . esc_html__( 'Examples:', 'llms-txt-for-wp' ) . '</strong></p>';
+				echo '<ul class="description" style="margin: 0 0 8px 20px;">';
+				foreach ( $field['examples'] as $example ) {
+					echo '<li>';
+					if ( is_array( $example ) ) {
+						if ( isset( $example['value'] ) ) {
+							echo '<code>' . esc_html( $example['value'] ) . '</code>';
+						}
+						if ( isset( $example['description'] ) && '' !== $example['description'] ) {
+							echo ' ' . esc_html( $example['description'] );
+						}
+					} else {
+						echo '<code>' . esc_html( $example ) . '</code>';
+					}
+					echo '</li>';
+				}
+				echo '</ul>';
+			}
+			echo '</td>';
+			echo '</tr>';
+		}
+		echo '</tbody></table>';
+	}
+
+	/**
+	 * Save llms.txt Page meta.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post Post object.
+	 */
+	public function save_llms_txt_page_meta( $post_id, $post ) {
+		if ( 'llms_txt_page' !== $post->post_type ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['llms_txt_page_meta_nonce'] ) || ! wp_verify_nonce( $_POST['llms_txt_page_meta_nonce'], 'llms_txt_page_meta' ) ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$fields = array(
+			'_llms_txt_header_scope' => 'sanitize_text_field',
+			'_llms_txt_output_parent' => 'sanitize_text_field',
+			'_llms_txt_header_authority_level' => 'sanitize_text_field',
+			'_llms_txt_header_content_type' => 'sanitize_text_field',
+		);
+
+		foreach ( $fields as $meta_key => $sanitize_callback ) {
+			if ( isset( $_POST[ $meta_key ] ) ) {
+				$value = call_user_func( $sanitize_callback, wp_unslash( $_POST[ $meta_key ] ) );
+				if ( '_llms_txt_output_parent' === $meta_key ) {
+					$value = trim( $value, '/' );
+				}
+				update_post_meta( $post_id, $meta_key, $value );
+			}
+		}
+	}
+
+	/**
+	 * Parse defaults from the header template.
+	 *
+	 * @return array
+	 */
+	private function get_header_template_defaults() {
+		return array(
+			'scope' => '',
+			'output_parent' => '',
+			'authority_level' => __( 'Authoritative', 'llms-txt-for-wp' ),
+			'content_type' => __( 'AI reference and summarization', 'llms-txt-for-wp' ),
+		);
+	}
+}

--- a/llms-txt-for-wp.php
+++ b/llms-txt-for-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: LLMs.txt for WP
  * Plugin URI: https://github.com/WP-Autoplugin/llms-txt-for-wp
  * Description: Generates LLM-friendly content as llms.txt and provides markdown versions of posts.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Balázs Piller
  * Author URI: https://wp-autoplugin.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define constants.
-define( 'LLMS_TXT_VERSION', '1.1.0' );
+define( 'LLMS_TXT_VERSION', '1.2.0' );
 define( 'LLMS_TXT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_FILE', __FILE__ );

--- a/llms-txt-for-wp.php
+++ b/llms-txt-for-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: LLMs.txt for WP
  * Plugin URI: https://github.com/WP-Autoplugin/llms-txt-for-wp
  * Description: Generates LLM-friendly content as llms.txt and provides markdown versions of posts.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Balázs Piller
  * Author URI: https://wp-autoplugin.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define constants.
-define( 'LLMS_TXT_VERSION', '1.2.0' );
+define( 'LLMS_TXT_VERSION', '1.2.1' );
 define( 'LLMS_TXT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_FILE', __FILE__ );

--- a/public/class-llms-txt-public.php
+++ b/public/class-llms-txt-public.php
@@ -166,7 +166,7 @@ class LLMS_Txt_Public {
 				if ( '' !== $header ) {
 					$output .= $header . "\n\n";
 				}
-				$output .= LLMS_Txt_Markdown::convert_post_to_markdown( $llms_page, false );
+				$output .= $llms_page->post_content;
 				$append_llms_pages = true;
 			}
 		} elseif ( ! empty( $settings['selected_post'] ) ) {

--- a/public/class-llms-txt-public.php
+++ b/public/class-llms-txt-public.php
@@ -125,8 +125,11 @@ class LLMS_Txt_Public {
 
 		$settings = LLMS_Txt_Core::get_settings();
 		$output   = '';
+		$source   = isset( $settings['source'] ) ? $settings['source'] : 'custom';
 
-		if ( ! empty( $settings['selected_post'] ) ) {
+		if ( 'custom' === $source ) {
+			$output .= isset( $settings['custom_text'] ) ? $settings['custom_text'] : '';
+		} elseif ( ! empty( $settings['selected_post'] ) ) {
 			// Selected post/page.
 			$post = get_post( $settings['selected_post'] );
 			if ( $post ) {


### PR DESCRIPTION
Summary of changes : added a new CPT to allow multiple llms.txt at different locations. You can now choose a source for your main llms.txt from Custom Text, Page or an LLMS.txt Page (cpt)

New features:

- **LLMs.txt Page CPT**: Create dedicated llms.txt pages with structured header fields and clean-editor mode.
- **Header Templates**: Control the llms.txt header output with placeholders like `{post_title}`, `{post_author}`, `{scope}`, `{canonical_url}`, and more.
- **Nested llms.txt URLs**: Serve llms.txt from a parent path like `/my-product/llms.txt` or `/documentation/llms.txt`.
- **Child References Section**: Optionally append a formatted list of child llms.txt pages to the root output.

New Admin Settings:

- **llms.txt Source**: Choose Custom Text, Page, or LLMs.txt Page.
- **Header Template**: Customize the header output for LLMs.txt Pages with placeholders.
- **LLMs.txt Page**: Pick the LLMs.txt Page to output.
- **Include All llms.txt Pages**: Append a child references section to the root llms.txt.
- **Include Header**: Customize the header text shown above the child references list.