### PR TITLE
Version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 LLMs.txt for WP is a WordPress plugin designed to generate machine-learning-friendly content from your site. It automatically creates an `llms.txt` file that compiles key content in a standardized format, making your site ready for Large Language Models (LLMs). This ensures that your content can be easily discovered and utilized by AI tools and applications.
 
-Additionally, this plugin allows you to access **Markdown versions of your posts** by appending `.md` to the post URLs or by sending an `Accept: text/markdown` header. Posts automatically include a `<link rel="alternate" type="text/markdown">` tag in their headers for better discoverability.
+Additionally, this plugin allows you to access **Markdown versions of your posts** by appending `.md` to the post URLs or by sending an `Accept: text/markdown` header. Posts automatically include a `<link rel="alternate" type="text/markdown">` tag in their HTML `<head>`, and a `Link` HTTP response header pointing to the Markdown version for better discoverability. Markdown responses include an `X-Markdown-Tokens` header indicating the token count of the output.
 
 ### About the `llms.txt` Standard
 
@@ -17,7 +17,7 @@ For more information on the `llms.txt` standard, visit the official website: [ht
 ### Key Features
 
 - **Generate llms.txt**: Aggregate key content from your site into an easy-to-read format for machine learning models.
-- **Markdown Support**: Generate Markdown versions of posts, suitable for LLMs or for lightweight sharing.
+- **Markdown Support**: Generate Markdown versions of posts, suitable for LLMs or for lightweight sharing. Markdown responses include an `X-Markdown-Tokens` header with the token count.
 - **Fully Customizable**: Customize which page or posts are included via an intuitive admin settings page.
 
 ## Installation
@@ -51,7 +51,9 @@ The `llms.txt` standard allows webmasters to provide structured data for Large L
 Once Markdown support is enabled, you can access Markdown versions in three ways:
 1. Append `.md` to any post's URL (e.g., `https://example.com/your-post.md`)
 2. Send an `Accept: text/markdown` header in your HTTP request
-3. Look for the `<link rel="alternate" type="text/markdown">` tag in the post's HTML header to discover the Markdown version
+3. Look for the `<link rel="alternate" type="text/markdown">` tag in the post's HTML `<head>` to discover the Markdown URL
+
+Markdown responses also include an `X-Markdown-Tokens` header indicating the approximate token count of the Markdown output, useful for LLM context management.
 
 ### Can I control which posts are included in llms.txt?
 
@@ -72,6 +74,11 @@ Yes! The plugin can be configured to include specific post types and limit the n
 You can view a demo of the plugin in action on my blog at [WebWizWork.com](https://www.webwizwork.com/llms.txt).
 
 ## Changelog
+
+## 1.1.1
+- Added X-Markdown-Tokens header for Markdown responses to indicate the number of tokens in the Markdown output.
+- Added a Link header with rel="alternate" and type="text/markdown" for Markdown-ready pages to improve discoverability of Markdown versions by LLMs and other tools.
+
 
 ### 1.1.0
 - Markdown versions can now be accessed by sending the "Accept: text/markdown" header.
@@ -95,4 +102,4 @@ Contributions are welcome! Feel free to fork the repository, submit issues, or c
 
 **Note:** This plugin uses the [league/html-to-markdown](https://github.com/thephpleague/html-to-markdown) library for HTML to Markdown conversion.
 
-Stable tag: 1.1.0
+Stable tag: 1.1.1

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ You can view a demo of the plugin in action on my blog at [WebWizWork.com](https
 - Added X-Markdown-Tokens header for Markdown responses to indicate the number of tokens in the Markdown output.
 - Added a Link header with rel="alternate" and type="text/markdown" for Markdown-ready pages to improve discoverability of Markdown versions by LLMs and other tools.
 
-
 ### 1.1.0
 - Markdown versions can now be accessed by sending the "Accept: text/markdown" header.
 - link rel="alternate" type="text/markdown" added to post headers for better discoverability of Markdown versions.

--- a/includes/class-llms-txt-core.php
+++ b/includes/class-llms-txt-core.php
@@ -56,6 +56,7 @@ class LLMS_Txt_Core {
 		add_filter( 'query_vars', array( $this->public, 'add_query_vars' ) );
 		add_action( 'template_redirect', array( $this->public, 'handle_markdown_requests' ), 1 );
 		add_action( 'template_redirect', array( $this->public, 'handle_llms_txt_requests' ), 1 );
+		add_action( 'send_headers', array( $this->public, 'output_markdown_alternate_header' ) );
 		add_action( 'wp_head', array( $this->public, 'output_markdown_alternate_link' ) );
 
 		// Activation hook to flush rewrite rules.

--- a/llms-txt-for-wp.php
+++ b/llms-txt-for-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: LLMs.txt for WP
  * Plugin URI: https://github.com/WP-Autoplugin/llms-txt-for-wp
  * Description: Generates LLM-friendly content as llms.txt and provides markdown versions of posts.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Balázs Piller
  * Author URI: https://wp-autoplugin.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define constants.
-define( 'LLMS_TXT_VERSION', '1.1.0' );
+define( 'LLMS_TXT_VERSION', '1.1.1' );
 define( 'LLMS_TXT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'LLMS_TXT_PLUGIN_FILE', __FILE__ );


### PR DESCRIPTION
- Added X-Markdown-Tokens header for Markdown responses to indicate the number of tokens in the Markdown output.
- Added a Link header with rel="alternate" and type="text/markdown" for Markdown-ready pages to improve discoverability of Markdown versions by LLMs and other tools.